### PR TITLE
Add NTP during boot (fixes #37)

### DIFF
--- a/config/etc/ntp.conf
+++ b/config/etc/ntp.conf
@@ -1,0 +1,5 @@
+server 0.pool.ntp.org
+server 1.pool.ntp.org
+server 2.pool.ntp.org
+server 3.pool.ntp.org
+

--- a/config/etc/zero-os/conf/ntp.conf
+++ b/config/etc/zero-os/conf/ntp.conf
@@ -1,0 +1,8 @@
+[startup.ntpd]
+name = "core.system"
+after = ["init"]
+protected = true
+
+[startup.ntpd.args]
+name = "ntpd"
+args = ["-n"]

--- a/config/etc/zero-os/conf/ntp.conf
+++ b/config/etc/zero-os/conf/ntp.conf
@@ -1,8 +1,7 @@
 [startup.ntpd]
 name = "core.system"
-after = ["init"]
 protected = true
 
 [startup.ntpd.args]
 name = "ntpd"
-args = ["-n"]
+args = ["-n", "-d"]

--- a/config/etc/zero-os/conf/ntp.toml
+++ b/config/etc/zero-os/conf/ntp.toml
@@ -5,4 +5,4 @@ protected = true
 
 [startup.ntpd.args]
 name = "ntpd"
-args = ["-n", "-d"]
+args = ["-n"]

--- a/config/etc/zero-os/conf/ntp.toml
+++ b/config/etc/zero-os/conf/ntp.toml
@@ -1,5 +1,6 @@
 [startup.ntpd]
 name = "core.system"
+after = ["init"]
 protected = true
 
 [startup.ntpd.args]


### PR DESCRIPTION
This pull request fixes issue #37 and add NTP daemon during boot and ensure time to be updated constantly.

This PR was tested on ovh node:
```
~ # date -s '2017-05-05 13:37:00'
Fri May  5 13:37:00 UTC 2017

~ # hwclock -w
~ # date
Fri May  5 13:37:06 UTC 2017

~ # reboot

[rebooted]

~ # date
Fri May  5 13:41:06 UTC 2017

~ # reboot

[rebooted using ntp image]

~ # date
Mon Jun 12 11:17:34 UTC 2017
```