### PR TITLE
Bump nftables 0.7 and libnftnl 1.0.7

### DIFF
--- a/internals/nftables.sh
+++ b/internals/nftables.sh
@@ -1,9 +1,9 @@
-NFTABLES_VERSION="0.6"
-NFTABLES_CHECKSUM="fd320e35fdf14b7be795492189b13dae"
+NFTABLES_VERSION="0.7"
+NFTABLES_CHECKSUM="4c005e76a15a029afaba71d7db21d065"
 NFTABLES_LINK="https://www.netfilter.org/projects/nftables/files/nftables-${NFTABLES_VERSION}.tar.bz2"
 
-LIBNFTNL_VERSION="1.0.6"
-LIBNFTNL_CHECKSUM="6d7f9f161538ca7efd535dcc70caf964"
+LIBNFTNL_VERSION="1.0.7"
+LIBNFTNL_CHECKSUM="82183867168eb6644926c48b991b8aac"
 LIBNFTNL_LINK="http://www.iptables.org/projects/libnftnl/files/libnftnl-${LIBNFTNL_VERSION}.tar.bz2"
 
 download_nftables() {
@@ -40,6 +40,9 @@ prepare_nftables() {
 
     # Force to skip documentation compilation
     echo "all:" > doc/Makefile
+
+    # Patching nftables
+    patch -p1 < "${PATCHESDIR}/nftables-0.7-dest-ip-port.patch"
 }
 
 compile_nftables() {

--- a/patches/nftables-0.7-dest-ip-port.patch
+++ b/patches/nftables-0.7-dest-ip-port.patch
@@ -1,0 +1,48 @@
+diff --git a/src/statement.c b/src/statement.c
+index 9cdabbb979e8..3beb86ab4263 100644
+--- a/src/statement.c
++++ b/src/statement.c
+@@ -508,6 +508,8 @@ static void nat_stmt_print(const struct stmt *stmt)
+ 				printf("]-[");
+ 				expr_print(stmt->nat.addr->right);
+ 				printf("]");
++			} else {
++				expr_print(stmt->nat.addr);
+ 			}
+ 		} else {
+ 			expr_print(stmt->nat.addr);
+diff --git a/tests/py/ip/dnat.t b/tests/py/ip/dnat.t
+index da00106edbb4..089017c84704 100644
+--- a/tests/py/ip/dnat.t
++++ b/tests/py/ip/dnat.t
+@@ -7,6 +7,7 @@ iifname "eth0" tcp dport != 80-90 dnat to 192.168.3.2;ok
+ iifname "eth0" tcp dport {80, 90, 23} dnat to 192.168.3.2;ok
+ iifname "eth0" tcp dport != {80, 90, 23} dnat to 192.168.3.2;ok
+ iifname "eth0" tcp dport != 23-34 dnat to 192.168.3.2;ok
++iifname "eth0" tcp dport 81 dnat to 192.168.3.2:8080;ok
+ 
+ dnat to ct mark map { 0x00000014 : 1.2.3.4};ok
+ dnat to ct mark . ip daddr map { 0x00000014 . 1.1.1.1 : 1.2.3.4};ok
+diff --git a/tests/py/ip/dnat.t.payload.ip b/tests/py/ip/dnat.t.payload.ip
+index 66926990d880..7a7f5a82dd5a 100644
+--- a/tests/py/ip/dnat.t.payload.ip
++++ b/tests/py/ip/dnat.t.payload.ip
+@@ -60,6 +60,18 @@ ip test-ip4 prerouting
+   [ immediate reg 1 0x0203a8c0 ]
+   [ nat dnat ip addr_min reg 1 addr_max reg 0 ]
+ 
++# iifname "eth0" tcp dport 81 dnat to 192.168.3.2:8080
++ip test-ip4 prerouting
++  [ meta load iifname => reg 1 ]
++  [ cmp eq reg 1 0x30687465 0x00000000 0x00000000 0x00000000 ]
++  [ payload load 1b @ network header + 9 => reg 1 ]
++  [ cmp eq reg 1 0x00000006 ]
++  [ payload load 2b @ transport header + 2 => reg 1 ]
++  [ cmp eq reg 1 0x00005100 ]
++  [ immediate reg 1 0x0203a8c0 ]
++  [ immediate reg 2 0x0000901f ]
++  [ nat dnat ip addr_min reg 1 addr_max reg 0 proto_min reg 2 proto_max reg 0 ]
++
+ # dnat to ct mark map { 0x00000014 : 1.2.3.4}
+ __map%d test-ip4 b
+ __map%d test-ip4 0


### PR DESCRIPTION
Kernel tested: `client nft.open_port` still works and container reachs internet.