### PR TITLE
Remove ork from processes started on boot

### DIFF
--- a/config/etc/zero-os/conf/ork.toml
+++ b/config/etc/zero-os/conf/ork.toml
@@ -1,7 +1,0 @@
-[startup."ork.job"]
-name = "core.system"
-after = ["init"]
-protected = true
-
-[startup."ork.job".args]
-name = "0-ork"


### PR DESCRIPTION
Ork is too aggressive so we need to remove it for now until it is tweeked a bit.