### PR TITLE
Add debugfs utility (fixes #60, #61, #62, #68 and #70)

### DIFF
--- a/config/debugfs/debugfs
+++ b/config/debugfs/debugfs
@@ -4,8 +4,8 @@ debugroot="/mnt/debugfs"
 
 echo "[+] preparing debug environment"
 
-if [ ! -e /tmp/ubuntu1604.flist ]; then
-    wget https://hub.gig.tech/maxux/ubuntu-debugfs.flist -O /tmp/ubuntu1604.flist
+if [ ! -e /tmp/ubuntu-debugfs.flist ]; then
+    wget https://hub.gig.tech/maxux/ubuntu-debugfs.flist -O /tmp/ubuntu-debugfs.flist
 fi
 
 mkdir -p ${debugroot}/backend
@@ -21,7 +21,7 @@ if ps aux | grep g8ufs | grep -q debugfs; then
 fi
 
 echo "[+] starting the fuse filesystem"
-g8ufs -backend ${debugroot}/backend -meta /tmp/ubuntu1604.flist ${debugroot}/image/ &
+g8ufs -backend ${debugroot}/backend -meta /tmp/ubuntu-debugfs.flist ${debugroot}/image/ &
 
 echo "[+] waiting for the filesystem"
 while [ ! -f ${debugroot}/image/bin/bash ]; do
@@ -36,13 +36,6 @@ mount -o bind /sys ${debugroot}/image/sys
 
 mount -o bind /dev ${debugroot}/image/dev
 mount -o bind /dev/pts ${debugroot}/image/dev/pts
-
-if ! grep -q debugfs ${debugroot}/image/root/.bashrc; then
-    echo 'export PS1="(debugfs) $PS1"' >> ${debugroot}/image/root/.bashrc
-fi
-
-echo "[+] updating environment"
-chroot ${debugroot}/image apt-get update
 
 echo "[+] entering debug environment"
 chroot ${debugroot}/image /bin/bash

--- a/config/debugfs/debugfs
+++ b/config/debugfs/debugfs
@@ -15,13 +15,15 @@ echo "[+] ensure debug environment sanity"
 umount -r ${debugroot}/image 2> /dev/null
 umount -r ${debugroot}/backend/ro 2> /dev/null
 
+backendaddr=$(grep 'storage = ' /etc/zero-os/zero-os.toml | cut -d'"' -f2)
+
 # killing previous debugfs instance
 if ps aux | grep g8ufs | grep -q debugfs; then
     kill -9 $(ps aux | grep g8ufs | grep debugfs | awk '{ print $1 }' | xargs)
 fi
 
 echo "[+] starting the fuse filesystem"
-g8ufs -backend ${debugroot}/backend -meta /tmp/ubuntu-debugfs.flist ${debugroot}/image/ &
+g8ufs -backend ${debugroot}/backend -storage-url "${backendaddr}" -meta /tmp/ubuntu-debugfs.flist ${debugroot}/image/ &
 
 echo "[+] waiting for the filesystem"
 while [ ! -f ${debugroot}/image/bin/bash ]; do

--- a/config/debugfs/debugfs
+++ b/config/debugfs/debugfs
@@ -1,0 +1,48 @@
+#!/bin/sh
+
+debugroot="/mnt/debugfs"
+
+echo "[+] preparing debug environment"
+
+if [ ! -e /tmp/ubuntu1604.flist ]; then
+    wget https://hub.gig.tech/maxux/ubuntu-debugfs.flist -O /tmp/ubuntu1604.flist
+fi
+
+mkdir -p ${debugroot}/backend
+mkdir -p ${debugroot}/image
+
+echo "[+] ensure debug environment sanity"
+umount -r ${debugroot}/image 2> /dev/null
+umount -r ${debugroot}/backend/ro 2> /dev/null
+
+# killing previous debugfs instance
+if ps aux | grep g8ufs | grep -q debugfs; then
+    kill -9 $(ps aux | grep g8ufs | grep debugfs | awk '{ print $1 }' | xargs)
+fi
+
+echo "[+] starting the fuse filesystem"
+g8ufs -backend ${debugroot}/backend -meta /tmp/ubuntu1604.flist ${debugroot}/image/ &
+
+echo "[+] waiting for the filesystem"
+while [ ! -f ${debugroot}/image/bin/bash ]; do
+    sleep 0.1
+done
+
+echo "[+] configuring environment"
+cp -L /etc/resolv.conf ${debugroot}/image/etc/resolv.conf
+
+mount -t proc none ${debugroot}/image/proc
+mount -o bind /sys ${debugroot}/image/sys
+
+mount -o bind /dev ${debugroot}/image/dev
+mount -o bind /dev/pts ${debugroot}/image/dev/pts
+
+if ! grep -q debugfs ${debugroot}/image/root/.bashrc; then
+    echo 'export PS1="(debugfs) $PS1"' >> ${debugroot}/image/root/.bashrc
+fi
+
+echo "[+] updating environment"
+chroot ${debugroot}/image apt-get update
+
+echo "[+] entering debug environment"
+chroot ${debugroot}/image /bin/bash

--- a/config/debugfs/debugfs
+++ b/config/debugfs/debugfs
@@ -5,7 +5,7 @@ debugroot="/mnt/debugfs"
 echo "[+] preparing debug environment"
 
 if [ ! -e /tmp/ubuntu-debugfs.flist ]; then
-    wget https://hub.gig.tech/maxux/ubuntu-debugfs.flist -O /tmp/ubuntu-debugfs.flist
+    wget https://hub.gig.tech/gig-official-apps/ubuntu-debugfs.flist -O /tmp/ubuntu-debugfs.flist
 fi
 
 mkdir -p ${debugroot}/backend

--- a/config/debugfs/debugfs-flist.sh
+++ b/config/debugfs/debugfs-flist.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+
+ROOTBUNTU="/tmp/ubuntu-xenial"
+TARGET="/tmp/ubuntu-debugfs.tar.gz"
+
+# preparing target
+mkdir -p ${ROOTBUNTU}
+rm -rf ${ROOTBUNTU}/*
+rm -rf ${TARGET}
+
+# installing system
+debootstrap \
+  --arch=amd64 \
+  --components=main,restricted,universe,multiverse \
+  --include curl,ca-certificates,tcpdump,ethtool,pciutils,strace,lsof,htop,binutils \
+  xenial ${ROOTBUNTU} \
+  http://archive.ubuntu.com/ubuntu/
+
+echo "Debugfs base system installed"
+
+files=$(find ${ROOTBUNTU} | wc -l)
+rootsize=$(du -sh ${ROOTBUNTU})
+echo "${rootsize}, ${files} files installed"
+
+echo "Cleaning installation..."
+
+# cleaning documentation and not needed files
+find ${ROOTBUNTU}/usr/share/doc -type f ! -name 'copyright' | xargs rm -f
+find ${ROOTBUNTU}/usr/share/locale -mindepth 1 -maxdepth 1 ! -name 'en' | xargs rm -rf
+rm -rf ${ROOTBUNTU}/usr/share/info
+rm -rf ${ROOTBUNTU}/usr/share/man
+rm -rf ${ROOTBUNTU}/usr/share/lintian
+rm -rf ${ROOTBUNTU}/var/cache/apt/archives/*deb
+rm -rf ${ROOTBUNTU}/var/lib/apt/lists/*_Packages
+
+files=$(find ${ROOTBUNTU} | wc -l)
+rootsize=$(du -sh ${ROOTBUNTU})
+echo "${rootsize}, ${files} files installed"
+
+echo "Archiving..."
+pushd ${ROOTBUNTU}
+tar -czf ${TARGET} *
+popd
+
+ls -alh ${TARGET}
+echo "Debugfs flist is ready."

--- a/config/debugfs/debugfs-flist.sh
+++ b/config/debugfs/debugfs-flist.sh
@@ -8,6 +8,11 @@ mkdir -p ${ROOTBUNTU}
 rm -rf ${ROOTBUNTU}/*
 rm -rf ${TARGET}
 
+echo "Installing image into: ${ROOTBUNTU}"
+echo "Exporting flist to: ${TARGET}"
+echo ""
+echo "Bootstrapping the base image..."
+
 # installing system
 debootstrap \
   --arch=amd64 \
@@ -21,6 +26,16 @@ echo "Debugfs base system installed"
 files=$(find ${ROOTBUNTU} | wc -l)
 rootsize=$(du -sh ${ROOTBUNTU})
 echo "${rootsize}, ${files} files installed"
+
+echo "Customizing settings..."
+
+touch ${ROOTBUNTU}/root/.sudo_as_admin_successful
+echo 'export PS1="(debugfs) $PS1"' >> ${ROOTBUNTU}/root/.bashrc
+echo 'cat /root/.debugfs' >> ${ROOTBUNTU}/root/.bashrc
+
+echo "You are now on debugfs environment" > ${ROOTBUNTU}/root/.debugfs
+echo "Don't forget to 'apt-get update' before installing new packages" >> ${ROOTBUNTU}/root/.debugfs
+echo "" >> ${ROOTBUNTU}/root/.debugfs
 
 echo "Cleaning installation..."
 

--- a/config/debugfs/ssh-add-github-key
+++ b/config/debugfs/ssh-add-github-key
@@ -1,0 +1,27 @@
+#!/bin/sh
+set -e
+
+if [ "$1" = "" ]; then
+    echo "[-] missing github username"
+    exit 1
+fi
+
+TARGET="$1"
+
+echo "[+] authorizing ${TARGET}"
+
+SK=$(wget -q https://github.com/${TARGET}.keys -O - | tail -1)
+
+if [ "$SK" == "Not Found" ]; then
+	echo "[-] user not found"
+	exit 1
+fi
+
+mkdir -p /root/.ssh
+
+if ! grep "$SK" /root/.ssh/authorized_keys > /dev/null 2>&1; then
+	echo "$SK ${TARGET}@github" >> /root/.ssh/authorized_keys
+	echo "[+] key authorized"
+else
+	echo "[-] already authorized"
+fi

--- a/initramfs.sh
+++ b/initramfs.sh
@@ -448,6 +448,7 @@ g8os_root() {
 
     # Debugfs tool
     cp -a "${CONFDIR}"/debugfs/debugfs "${ROOTDIR}"/usr/sbin/
+    cp -a "${CONFDIR}"/debugfs/ssh-add-github-key "${ROOTDIR}"/usr/sbin/
 }
 
 #

--- a/initramfs.sh
+++ b/initramfs.sh
@@ -445,6 +445,9 @@ g8os_root() {
 
     # System scripts
     cp -a "${CONFDIR}"/usr/udhcp "${ROOTDIR}"/usr/share/
+
+    # Debugfs tool
+    cp -a "${CONFDIR}"/debugfs/debugfs "${ROOTDIR}"/usr/sbin/
 }
 
 #


### PR DESCRIPTION
Here are `debugfs` tools used to debug the host system without adding software to the initramfs.
This commit contains a script used to create the flist used as root for `debugfs` chroot.

The `debugfs` utility mount a debug flist into `/mnt/debugfs` and chroot into it. There is no "container" restriction, the chroot can fully access the host system (except host filesystem, but this can be added) and contains tools for debugging the system. Any new software can be `apt-get` during runtime if needed.

This `debugfs` is useful to troobleshoot network, system, hardware, etc. without growing the initramfs.