### PR TITLE
Optional compactation of object files when kernel is compiled

### DIFF
--- a/autobuild/gig-build.sh
+++ b/autobuild/gig-build.sh
@@ -19,7 +19,7 @@ apt-get install -y xz-utils pkg-config lbzip2 make curl libtool gettext m4 autoc
 curl https://storage.googleapis.com/golang/go1.8.linux-amd64.tar.gz > /tmp/go1.8.linux-amd64.tar.gz
 tar -C /usr/local -xzf /tmp/go1.8.linux-amd64.tar.gz
 export PATH=$PATH:/usr/local/go/bin
-mkdir /gopath
+mkdir -p /gopath
 export GOPATH=/gopath
 
 # adding extensions (fallback to master if branch not found)
@@ -27,7 +27,7 @@ cd "/$2/extensions"
 git clone -b "$1" https://github.com/zero-os/initramfs-gig || git clone https://github.com/zero-os/initramfs-gig
 
 # checkings arguments
-arguments=""
+arguments="--compact "
 if [ "${1:0:7}" = "release" ]; then
     arguments="--release"
 fi

--- a/autobuild/gig-build.sh
+++ b/autobuild/gig-build.sh
@@ -27,7 +27,7 @@ cd "/$2/extensions"
 git clone -b "$1" https://github.com/zero-os/initramfs-gig || git clone https://github.com/zero-os/initramfs-gig
 
 # checkings arguments
-arguments="--compact "
+arguments="--all --compact "
 if [ "${1:0:7}" = "release" ]; then
     arguments="--release"
 fi

--- a/initramfs.sh
+++ b/initramfs.sh
@@ -384,6 +384,7 @@ clean_staging() {
 
     rm -rf "${DISTFILES}"/*
     mv -f "${WORKDIR}"/linux-* "${TMPDIR}"/
+    mv -f "${WORKDIR}"/vmlinuz* "${TMPDIR}"/
     rm -rf "${WORKDIR}"/*
 }
 

--- a/initramfs.sh
+++ b/initramfs.sh
@@ -9,6 +9,7 @@ DISTFILES="${PWD}/archives"
 WORKDIR="${PWD}/staging"
 CONFDIR="${PWD}/config"
 ROOTDIR="${PWD}/root"
+TMPDIR="${PWD}/tmp"
 INTERNAL="${PWD}/internals/"
 EXTENDIR="${PWD}/extensions/"
 PATCHESDIR="${PWD}/patches/"
@@ -21,7 +22,7 @@ MAKEOPTS="-j ${JOBS}"
 #
 # Flags
 #
-OPTS=$(getopt -o dbtckMeolmrh --long download,busybox,tools,cores,kernel,modules,extensions,ork,clean,mrproper,release,help -n 'parse-options' -- "$@")
+OPTS=$(getopt -o adbtckMeolmzrh --long all,download,busybox,tools,cores,kernel,modules,extensions,ork,clean,mrproper,compact,release,help -n 'parse-options' -- "$@")
 if [ $? != 0 ]; then
     echo "Failed parsing options." >&2
     exit 1
@@ -42,12 +43,14 @@ if [ "$OPTS" != " --" ] && [ "$OPTS" != " --release --" ]; then
     DO_CLEAN=0
     DO_MRPROPER=0
     DO_ORK=0
+    DO_COMPACT=0
 
     eval set -- "$OPTS"
 fi
 
 while true; do
     case "$1" in
+        -a | --all)        DO_ALL=1;            shift ;;
         -d | --download)   DO_DOWNLOAD=1;       shift ;;
         -b | --busybox)    DO_BUSYBOX=1;        shift ;;
         -t | --tools)      DO_TOOLS=1;          shift ;;
@@ -57,10 +60,12 @@ while true; do
         -e | --extensions) DO_EXTENSIONS=1;     shift ;;
         -o | --ork)        DO_ORK=1;            shift ;;
         -l | --clean)      DO_CLEAN=1;          shift ;;
+        -z | --compact)    DO_COMPACT=1;        shift ;;
         -m | --mrproper)   DO_MRPROPER=1;       shift ;;
         -r | --release)    BUILDMODE="release"; shift ;;
         -h | --help)
             echo "Usage:"
+            echo " -a --all         do everything (default, like no argument)"
             echo " -d --download    only download and extract archives"
             echo " -b --busybox     only (re)build busybox"
             echo " -t --tools       only (re)build tools (ssl, fuse, ...)"
@@ -71,6 +76,7 @@ while true; do
             echo " -o --ork         only (re)build ork protection"
             echo " -l --clean       only clean staging files (extracted sources)"
             echo " -m --mrproper    only remove staging files and clean the root"
+            echo " -z --compact     clean staging file when compilation is done (except kernel)"
             echo " -r --release     force a release build"
             echo " -h --help        display this help message"
             exit 1
@@ -373,6 +379,14 @@ clean_root() {
     popd
 }
 
+clean_staging() {
+    echo "[+] cleaning staging files"
+
+    rm -rf "${DISTFILES}"/*
+    mv -f "${WORKDIR}"/linux-* "${TMPDIR}"/
+    rm -rf "${WORKDIR}"/*
+}
+
 optimize_size() {
     echo "[+] optimizing binaries size"
     pushd "${ROOTDIR}"
@@ -613,6 +627,10 @@ main() {
         g8os_root
         build_kernel
         end_summary
+    fi
+
+    if [[ $DO_COMPACT == 1 ]]; then
+        clean_staging
     fi
 }
 

--- a/initramfs.sh
+++ b/initramfs.sh
@@ -420,6 +420,7 @@ clean_staging() {
     rm -rf "${TMPDIR}"/*
     mv -f "${WORKDIR}"/linux-* "${TMPDIR}"/
     mv -f "${WORKDIR}"/vmlinuz* "${TMPDIR}"/
+    mv -f "${WORKDIR}"/rocksdb* "${TMPDIR}"/
 
     # cleaning staging files
     rm -rf "${WORKDIR}"/*

--- a/initramfs.sh
+++ b/initramfs.sh
@@ -382,10 +382,19 @@ clean_root() {
 clean_staging() {
     echo "[+] cleaning staging files"
 
+    # removing archives
     rm -rf "${DISTFILES}"/*
+
+    # saving kernel
+    rm -rf "${TMPDIR}"/*
     mv -f "${WORKDIR}"/linux-* "${TMPDIR}"/
     mv -f "${WORKDIR}"/vmlinuz* "${TMPDIR}"/
+
+    # cleaning staging files
     rm -rf "${WORKDIR}"/*
+
+    # restoring kernel
+    mv "${TMPDIR}"/* "${WORKDIR}"/
 }
 
 optimize_size() {


### PR DESCRIPTION
This reduce builder directory from ~6 GB to ~4 GB after the build, without loosing possibility to change the root/rebuild the kernel quickly.