### PR TITLE
use address family based flush, as otherwise we loose ipv6

### DIFF
--- a/config/usr/udhcp/simple.script
+++ b/config/usr/udhcp/simple.script
@@ -8,13 +8,13 @@ RESOLV_CONF="${ROOT}/etc/resolv.conf"
 case "$1" in
     deconfig)
         echo "Setting IP address 0.0.0.0 on $interface"
-        ip addr flush dev $interface
+        ip -4 addr flush dev $interface
         ip link set $interface up
         ;;
 
     renew|bound)
         echo "Setting IP address $ip on $interface"
-        ip addr flush dev $interface
+        ip -4 addr flush dev $interface
         ip addr add ${ip}/${mask} dev $interface
 
         [ -n "$router" ] && ip route add default via ${router%% *} dev $interface


### PR DESCRIPTION
If you do a full flush of an interface, SLAAC and ipv6-ll is also unconfigured, leaving an ipv4-only network.
So we flush only addr family ipv4.

